### PR TITLE
Remove RHEL activation logic to install libdb-cxx-devel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,6 @@ jobs:
           context: .
           tags: builder
           load: true
-          secrets: |
-            redhat_org=${{ secrets.REDHAT_ORG }}
       - name: Run
         run: |
           patch -p1 -d ice < 0001-OpenSSL-3.0-build-See-zeroc-ice-ice-1320.patch

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ FROM redhat/ubi9
 
 ENV SMDEV_CONTAINER_OFF=1
 
-RUN --mount=type=secret,id=redhat_org subscription-manager register --org $(cat /run/secrets/redhat_org) --activationkey Ice
-RUN subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
-
 RUN dnf update -y
 
 RUN dnf install -y \
@@ -22,5 +19,3 @@ RUN dnf install -y \
 # Install mcpp
 RUN dnf install -y https://zeroc.com/download/ice/3.7/el8/ice-repo-3.7.el8.noarch.rpm && \
     dnf install -y mcpp-devel
-
-RUN subscription-manager unregister


### PR DESCRIPTION
The library is now available from the UBI9 repositories - see https://issues.redhat.com/browse/RHEL-3834